### PR TITLE
Update requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # make sure to update setup.py if you make any changes to this file
 
 argcomplete>=1.11.1
-pygit2==1.4.0  # requires libgit2 1.1.x
+pygit2>=1.4.0  # requires libgit2 1.1.x

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     packages=['gitless', 'gitless.cli'],
     install_requires=[
         # make sure install_requires is consistent with requirements.txt
-        'pygit2==1.4.0',  # requires libgit2 1.1.x
+        'pygit2>=1.4.0',  # requires libgit2 1.1.x
         'argcomplete>=1.11.1'
     ],
     license='MIT',


### PR DESCRIPTION
This simple change will allow gitless to continue to work when you upgrade pygit2 to a newer version. 

Tested on Arch Linux and pygit 1.8

Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>