### PR TITLE
Add check before removing file from index.

### DIFF
--- a/gitless/core.py
+++ b/gitless/core.py
@@ -1253,7 +1253,9 @@ class Branch(object):
                     assert not os.path.isabs(f)
                     git_f = _get_git_path(f)
                     if not os.path.exists(os.path.join(self.gl_repo.root, f)):
-                        index.remove(git_f)
+                        # Check if this file has been removed using `git mv` or `git rm`
+                        if git_f in index._git_index:
+                            index.remove(git_f)
                     elif f not in partials:
                         index.add(git_f)
 


### PR DESCRIPTION
Using `git rm <file>` and `git mv <file>` update the index so it's a no-op w.r.t updating the index
Fixes https://github.com/goldstar611/gitless/issues/17
Fixes https://github.com/gitless-vcs/gitless/issues/231
Fixes https://github.com/gitless-vcs/gitless/issues/153
Fixes https://github.com/gitless-vcs/gitless/issues/63