### PR TITLE
Add git fetch wrapper

### DIFF
--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -17,7 +17,7 @@ from .. import core, __version__
 from . import (
     gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
     gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-    gl_switch, gl_init, gl_history, gl_ignore, gl_fetch)
+    gl_switch, gl_init, gl_history, gl_ignore, gl_fetch, gl_pull)
 from . import pprint
 from . import helpers
 
@@ -91,7 +91,7 @@ def main():
     sub_cmds = [
         gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
         gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch]
+        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch ,gl_pull]
 
     parser = build_parser(sub_cmds, repo)
     argcomplete.autocomplete(parser)

--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -17,7 +17,7 @@ from .. import core, __version__
 from . import (
     gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
     gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-    gl_switch, gl_init, gl_history, gl_ignore)
+    gl_switch, gl_init, gl_history, gl_ignore, gl_fetch)
 from . import pprint
 from . import helpers
 
@@ -91,7 +91,7 @@ def main():
     sub_cmds = [
         gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
         gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-        gl_switch, gl_init, gl_history, gl_ignore]
+        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch]
 
     parser = build_parser(sub_cmds, repo)
     argcomplete.autocomplete(parser)

--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -91,7 +91,7 @@ def main():
     sub_cmds = [
         gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
         gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch ,gl_pull]
+        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch, gl_pull]
 
     parser = build_parser(sub_cmds, repo)
     argcomplete.autocomplete(parser)

--- a/gitless/cli/gl_fetch.py
+++ b/gitless/cli/gl_fetch.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Gitless - a version control system built on top of Git
+# Licensed under MIT
+
+"""gl fetch - A wrapper around git-fetch(1)."""
+
+
+from ..import core
+
+
+def parser(subparsers, _):
+    """Adds the fetch parser to the given subparsers object."""
+    desc = 'Synchronize branches, tags, references and other meta data from another repository.\n' \
+           'For more information on this advanced command refer to the manual page for git-fetch.'
+    fetch_parser = subparsers.add_parser(
+        'fetch', help=desc, description=desc.capitalize(), aliases=['ft'])
+    fetch_parser.set_defaults(func=main)
+    fetch_parser.add_argument(
+        'fetch_args', nargs="*", help='Additional arguments to pass to `git fetch`')
+
+
+def main(args, repo):
+    core.git('fetch', *args.fetch_args)

--- a/gitless/cli/gl_pull.py
+++ b/gitless/cli/gl_pull.py
@@ -10,7 +10,7 @@ from ..import core
 
 def parser(subparsers, _):
     """Adds the pull parser to the given subparsers object."""
-    desc = 'Synchronize branches, tags, references and other meta data from mirror repository.\n' \
+    desc = 'Synchronize and merges branches, tags, references and other meta data from mirror repository.\n' \
            'For more information on this advanced command refer to the manual page for git-pull.'
     pull_parser = subparsers.add_parser(
         'pull', help=desc, description=desc.capitalize(), aliases=['pl'])

--- a/gitless/cli/gl_pull.py
+++ b/gitless/cli/gl_pull.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Gitless - a version control system built on top of Git
+# Licensed under MIT
+
+"""gl pull - A wrapper around git-pull(1)."""
+
+
+from ..import core
+
+
+def parser(subparsers, _):
+    """Adds the pull parser to the given subparsers object."""
+    desc = 'Synchronize branches, tags, references and other meta data from mirror repository.\n' \
+           'For more information on this advanced command refer to the manual page for git-pull.'
+    pull_parser = subparsers.add_parser(
+        'pull', help=desc, description=desc.capitalize(), aliases=['pl'])
+    pull_parser.set_defaults(func=main)
+    pull_parser.add_argument(
+        'pull_args', nargs="*", help='Additional arguments to pass to `git pull`')
+
+
+def main(args, repo):
+    core.git('pull', *args.pull_args)

--- a/gitless/cli/gl_remote.py
+++ b/gitless/cli/gl_remote.py
@@ -54,7 +54,7 @@ def main(args, repo):
 def _do_list(remotes):
     pprint.msg('List of remotes:')
     pprint.exp('do gl remote -c r r_url to add a new remote r mapping to r_url')
-    pprint.exp('do gl remote -u r r_url to change a new remote url to r_url')
+    pprint.exp('do gl remote -u r r_url to update an existing remote to r_url')
     pprint.exp('do gl remote -d r to delete remote r')
     pprint.blank()
 


### PR DESCRIPTION
Gitless provides no way to `fetch` or update tags/branches from a remote. This PR adds a thin wrapper around `git fetch`.

An extraneous change as also made it way into this PR.