### PR TITLE
Adds gl revert, a wrapper for git revert

### DIFF
--- a/gitless/cli/gl.py
+++ b/gitless/cli/gl.py
@@ -17,7 +17,7 @@ from .. import core, __version__
 from . import (
     gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
     gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-    gl_switch, gl_init, gl_history, gl_ignore, gl_fetch, gl_pull, gl_patch)
+    gl_switch, gl_init, gl_history, gl_ignore, gl_fetch, gl_pull, gl_patch, gl_revert)
 from . import pprint
 from . import helpers
 
@@ -91,7 +91,7 @@ def main():
     sub_cmds = [
         gl_track, gl_untrack, gl_status, gl_diff, gl_commit, gl_branch, gl_tag,
         gl_checkout, gl_merge, gl_resolve, gl_fuse, gl_remote, gl_publish,
-        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch, gl_pull, gl_patch]
+        gl_switch, gl_init, gl_history, gl_ignore, gl_fetch, gl_pull, gl_patch, gl_revert]
 
     parser = build_parser(sub_cmds, repo)
     argcomplete.autocomplete(parser)

--- a/gitless/cli/gl_revert.py
+++ b/gitless/cli/gl_revert.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Gitless - a version control system built on top of Git
+# Licensed under MIT
+
+"""gl revert - A wrapper around git-revert1)."""
+
+
+from ..import core
+from . import pprint
+
+def parser(subparsers, _):
+    """Adds the revert parser to the given subparsers object."""
+    desc = 'Revert some existing commits.\n' \
+           'For more information on this advanced command refer to the manual page for git-revert.'
+    revert_parser = subparsers.add_parser(
+        'revert', help=desc, description=desc.capitalize(), aliases=['re'])
+    revert_parser.set_defaults(func=main)
+    revert_parser.add_argument(
+        'revert_args', nargs="*", help='Additional arguments to pass to `git revert`')
+
+
+def main(args, repo):
+    p = core.git_wrap('revert', *args.revert_args)
+    if p.returncode == 0:
+        pprint.ok('Reverting commit sucessful')
+    else:
+        pprint.err('Reverting commit failed')
+    return p.returncode == 0


### PR DESCRIPTION
Very simply wrapper to git revert. I have done a simple test and it looks like everything is working. 

```
lucjan at archlinux ~/Pobrane/gitless 14:49:07 1a55d6c3 patch-6    
❯ gl revert HEAD            
[patch-6 847f8e6] Revert "Revert "Revert "Adds gl revert, a wrapper for git revert"""
 2 files changed, 2 insertions(+), 30 deletions(-)
 delete mode 100644 gitless/cli/gl_revert.py
✔ Reverting commit sucessful
lucjan at archlinux ~/Pobrane/gitless 14:49:16 847f8e6c patch-6    
❯ gl revert HEAD~1000...HEAD
fatal: bad revision 'HEAD~1000...HEAD'
✘ Reverting commit failed
```

Signed-off-by: Piotr Gorski <lucjan.lucjanov@gmail.com>